### PR TITLE
Move from mariadb:latest to mysql:latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mysql:
-    image: mariadb:latest
+    image: mysql:latest
     volumes:
       - "./data/db:/var/lib/mysql"
     restart: always


### PR DESCRIPTION
While MariaDB is awesome, the container is having issues with local volume mounts on Windows. The standard `mysql:latest` container, however, seems to sidestep these issues on Windows and still works seamlessly on Mac.

What's more, it appears that switching to `mysql:latest` on the container _retains_ the data originally written by MariaDB (in the event you're using an existing container stack).

Fixes #4.