### PR TITLE
Setup Script Instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,9 @@ The `/config/elasticsearch/plugins` folder is mapped to the plugins folder in th
 1. `git clone git@github.com:10up/wp-docker.git <my-project-name>`
 1. `cd <my-project-name>`
 1. `docker-compose up`
-1. Run `./bin/setup` to download WordPress and create a `wp-config.php` file.
+1. Run setup to download WordPress and create a `wp-config.php` file.
+	1. On Linux / Unix / OSX, run `sh bin/setup.sh`.
+	2. On Windows, run `./bin/setup`.
 1. Navigate to `http://localhost` in a browser to finish WordPress setup.
 
 Default MySQL connection information (from within PHP-FPM container):


### PR DESCRIPTION
The recent setup instruction changes are only applicable to the Windows OS. Running `./bin/setup` produces the following error: `no such file or directory: ./bin/setup`. This pull request adds OS specific instructions on running the setup command.