### PR TITLE
Make setup instructions a bit more clear

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The `/config/elasticsearch/plugins` folder is mapped to the plugins folder in th
 * [Docker](https://www.docker.com/)
 * [docker-compose](https://docs.docker.com/compose/)
 
-## Setup Docker
+## Setup a Docker Container
 
 1. `git clone git@github.com:10up/wp-docker.git <my-project-name>`
 1. `cd <my-project-name>`

--- a/readme.md
+++ b/readme.md
@@ -17,14 +17,17 @@ The `/config/elasticsearch/plugins` folder is mapped to the plugins folder in th
 * [Docker](https://www.docker.com/)
 * [docker-compose](https://docs.docker.com/compose/)
 
-## Setup
+## Setup Docker
 
 1. `git clone git@github.com:10up/wp-docker.git <my-project-name>`
 1. `cd <my-project-name>`
 1. `docker-compose up`
-1. Run setup to download WordPress and create a `wp-config.php` file.
-	1. On Linux / Unix / OSX, run `sh bin/setup.sh`.
-	2. On Windows, run `./bin/setup`.
+
+## Setup WordPress
+You will need to run a setup script to download WordPress and create a `wp-config.php` file. 
+1. With Docker running, open a new terminal window and CD into `<my-project-name>`
+	1. On Linux / Unix / OSX, run ```bash sh bin/setup.sh```
+	2. On Windows, run ```bash ./bin/setup```
 1. Navigate to `http://localhost` in a browser to finish WordPress setup.
 
 Default MySQL connection information (from within PHP-FPM container):


### PR DESCRIPTION
Break out setup into two sections 1) Docker 2) WordPress. Make it clear that Docker needs to be running in order to run setup script.