### PR TITLE
Switch to V3 of docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   mysql:
     image: mysql:latest


### PR DESCRIPTION
Fixes #12

Nothing in our docker-compose file wasn't compatible with v3, it was simply written before v3 was a thing.