### PR TITLE
Have phpfpm and nginx share the same "network card"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,15 +36,14 @@ services:
       - "./config/php-fpm/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
     restart: always
     build: ./dockerfiles/php-fpm
-    extra_hosts:
-      - "docker-local.dev:172.18.0.1"
+    ports:
+      - "80:80"
   nginx:
     depends_on:
       - phpfpm
-    ports:
-      - "80:80"
     image: nginx:latest
     volumes:
       - "./wordpress:/var/www/html"
       - "./config/nginx/default.conf:/etc/nginx/conf.d/default.conf"
     restart: always
+    network_mode: "service:phpfpm"


### PR DESCRIPTION
Pros:
- This allows wp-cron to work flawlessly.
- PHP code can call localhost:80 and it will work out of the box (great for legacy plugins/sites)
- No special hostnames and ip addresses

Cons:
- Not super scalable (but I don't think people should be using this compose file in production?)
- Kinda weird putting the ports for `nginx` on the `phpfpm` block