### PR TITLE
ElasticPress quick start bin scripts

### DIFF
--- a/bin/elasticpress.bat
+++ b/bin/elasticpress.bat
@@ -2,6 +2,6 @@
 
 docker-compose exec --user www-data phpfpm wp plugin install elasticpress --activate
 FOR /F "tokens=1,2 delims=/" %a IN ("docker-compose port elasticsearch 9200") DO set ip=%a&set port=%b
-set "host=http://docker-local.dev:%port%"
+set "host=http://elasticsearch:%port%"
 docker-compose exec --user www-data phpfpm wp option set ep_host "%host%"
 docker-compose exec --user www-data phpfpm wp elasticpress index

--- a/bin/elasticpress.bat
+++ b/bin/elasticpress.bat
@@ -1,0 +1,5 @@
+@echo off
+
+docker-compose exec --user www-data phpfpm wp plugin install elasticpress --activate
+docker-compose exec --user www-data phpfpm wp option set ep_host "http://docker-local.dev:$(docker-compose port elasticsearch 9200 | cut -f 2 -d ':')"
+docker-compose exec --user www-data phpfpm wp elasticpress index

--- a/bin/elasticpress.bat
+++ b/bin/elasticpress.bat
@@ -1,5 +1,7 @@
 @echo off
 
 docker-compose exec --user www-data phpfpm wp plugin install elasticpress --activate
-docker-compose exec --user www-data phpfpm wp option set ep_host "http://docker-local.dev:$(docker-compose port elasticsearch 9200 | cut -f 2 -d ':')"
+FOR /F "tokens=1,2 delims=/" %a IN ("docker-compose port elasticsearch 9200") DO set ip=%a&set port=%b
+set "host=http://docker-local.dev:%port%"
+docker-compose exec --user www-data phpfpm wp option set ep_host "%host%"
 docker-compose exec --user www-data phpfpm wp elasticpress index

--- a/bin/elasticpress.sh
+++ b/bin/elasticpress.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker-compose exec --user www-data phpfpm wp plugin install elasticpress --activate
+docker-compose exec --user www-data phpfpm wp option set ep_host "http://docker-local.dev:$(docker-compose port elasticsearch 9200 | cut -f 2 -d ':')"
+docker-compose exec --user www-data phpfpm wp elasticpress index

--- a/bin/elasticpress.sh
+++ b/bin/elasticpress.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 docker-compose exec --user www-data phpfpm wp plugin install elasticpress --activate
-docker-compose exec --user www-data phpfpm wp option set ep_host "http://docker-local.dev:$(docker-compose port elasticsearch 9200 | cut -f 2 -d ':')"
+docker-compose exec --user www-data phpfpm wp option set ep_host "http://elasticsearch:$(docker-compose port elasticsearch 9200 | cut -f 2 -d ':')"
 docker-compose exec --user www-data phpfpm wp elasticpress index


### PR DESCRIPTION
Adds quick start bin scripts for installing, activating, configuring, and indexing ElasticPress with the ES container.  I think this will bypass some confusion amongst users new to Docker networking.

Note: Will raise wp-cli warnings if ElasticPress is already activated and/or installed.  They can be ignored.