### PR TITLE
Add Mailcatcher

### DIFF
--- a/config/php-fpm/php.ini
+++ b/config/php-fpm/php.ini
@@ -2,3 +2,6 @@
 
 upload_max_filesize = 100M
 post_max_size = 100M
+
+[mail function]
+sendmail_path = /usr/bin/env catchmail -smtp-port 1025 -f allen.moore@10up.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,14 @@ services:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: password
+  mailcatcher:
+    image: schickling/mailcatcher
+    restart: always
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+    environment:
+      MAILCATCHER_PORT: 1025
   memcached:
     image: memcached:latest
     restart: always
@@ -28,6 +36,7 @@ services:
   phpfpm:
     depends_on:
       - mysql
+      - mailcatcher
       - memcached
       - elasticsearch
     volumes:

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,19 @@ This alias lets you run `dcbash` to SSH into the PHP/WordPress container.
 
 Alternatively, there is a script in the `/bin` directory that allows you to SSH in to the environment from the project directory directly: `./bin/ssh`.
 
+## MailCatcher
+
+MailCatcher runs a simple local SMTP server which catches any message sent to it, and displays it in it's built-in web interface. MailCatcher will not catch emails from a WordPress install unless WordPress's SMTP settings have been set to point to MailCatcher. [Multiple free plugins](https://wordpress.org/plugins/search/smtp/) are available on WordPress.org that make it easy to change WordPress's SMTP settings. The following settings should be added to the solution used to modify WordPress's SMTP Settings:
+
+```
+SMTP Host: yourlocalurl.tld or 0.0.0.0
+SMTP Port: 1025
+Encryption: No Encryption
+Authentication: Username and Password not required
+```
+
+To view the MailCatcher web interface, navigate to `http://yourlocalurl.tld:1080` or `http://0.0.0.0:1080` in your web browser of choice.
+
 ## Credits
 
 This project is our own flavor of an environment created by John Bloch.


### PR DESCRIPTION
MailCatcher is one of the tools built into VVV, which allows for local email testing, without storing email credentials in a database. I can't speak for everyone, but I've utilized MailCatcher quite a bit for multiple projects for testing HTML emails, custom user notifications, and more.

This pull request adds a new container for MailCatcher, using this container -- https://store.docker.com/community/images/schickling/mailcatcher. I've also added the necessary `sendmail_path` settings to the `php.ini` file and updated the `readme.md` file to include documentation for MailCatcher.