### PR TITLE
apt info is outdated at build

### DIFF
--- a/dockerfiles/php-fpm/Dockerfile
+++ b/dockerfiles/php-fpm/Dockerfile
@@ -4,15 +4,16 @@ RUN curl -L https://phar.phpunit.de/phpunit.phar > /tmp/phpunit.phar \
     && chmod +x /tmp/phpunit.phar \
     && mv /tmp/phpunit.phar /usr/local/bin/phpunit
 
-RUN apt-get install -y git subversion wget
+RUN apt-get update && apt-get install -y \
+        git \
+        subversion \
+        wget \
+	libxml2-dev \
+        ssmtp
 
-RUN apt-get update && \
-	apt-get install -y libxml2-dev && \
-	docker-php-ext-install soap
 
-RUN apt-get update && \
-	apt-get install -y ssmtp && \
-	echo "mailhub=mailcatcher:1025\nUseTLS=NO\nFromLineOverride=YES" > /etc/ssmtp/ssmtp.conf
+RUN docker-php-ext-install soap
+RUN echo "mailhub=mailcatcher:1025\nUseTLS=NO\nFromLineOverride=YES" > /etc/ssmtp/ssmtp.conf
 
 CMD ["php-fpm"]
 


### PR DESCRIPTION
apt-get update isn't being called prior to an install, with the age of the base image out of our control we must ensure apt-get update is called prior to any installs.

Also simplifies the routines