### PR TITLE
Expose nginx logs and add basic Xdebug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ config.codekit
 
 /data/*
 !/data/.gitkeep
+
+/logs/*
+!/logs/.gitkeep
+
 docker-compose.override.yml
 
 notes.md

--- a/config/php-fpm/docker-php-ext-xdebug.ini
+++ b/config/php-fpm/docker-php-ext-xdebug.ini
@@ -1,1 +1,6 @@
 zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so
+
+[Xdebug]
+xdebug.remote_enable = 1
+xdebug.remote_log = /var/log/xdebug/xdebug.log
+xdebug.remote_host = 172.18.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - "./wordpress:/var/www/html"
       - "./config/php-fpm/php.ini:/usr/local/etc/php/php.ini"
       - "./config/php-fpm/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "./logs/xdebug:/var/log/xdebug"
     restart: always
     build: ./dockerfiles/php-fpm
     extra_hosts:
@@ -55,4 +56,5 @@ services:
     volumes:
       - "./wordpress:/var/www/html"
       - "./config/nginx/default.conf:/etc/nginx/conf.d/default.conf"
+      - "./logs/nginx:/var/log/nginx"
     restart: always

--- a/logs/.gitkeep
+++ b/logs/.gitkeep
@@ -1,0 +1,1 @@
+# Basically just want to ignore the directory contents

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ MailCatcher runs a simple local SMTP server which catches any message sent to it
 
 ## Xdebug
 
-Xdebug is configured to run in remote debugging mode for Mac and Linux setups. If you are running Windows, replace the IP address on `config/php-fpm/docker-php-ext-xdebug.ini` to the IP address of your Network Bridge Adapter.
+Xdebug is configured to run in remote debugging mode for Mac and Linux setups. If you are running Windows, replace the IP address on `config/php-fpm/docker-php-ext-xdebug.ini` with the IP of your Network Bridge Adapter.
 
 ### Debugging
 

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,17 @@ Alternatively, there is a script in the `/bin` directory that allows you to SSH 
 
 MailCatcher runs a simple local SMTP server which catches any message sent to it, and displays it in it's built-in web interface. All emails sent by WordPress will be intercepted by MailCatcher. To view emails in the MailCatcher web interface, navigate to `http://localhost:1080` in your web browser of choice.
 
+## Xdebug
+
+Xdebug is configured to run in remote debugging mode for Mac and Linux setups. If you are running Windows, replace the IP address on `config/php-fpm/docker-php-ext-xdebug.ini` to the IP address of your Network Bridge Adapter.
+
+### Debugging
+
+1. Install the Xdebug helper Chrome Extension
+1. Click the Xdebug helper icon and select "Debug"
+1. Tell your IDE to listen to external Debug Connections
+    1. On PHPStorm:  Run > Start Listening to PHP Debug Connections
+
 ## Credits
 
 This project is our own flavor of an environment created by John Bloch.


### PR DESCRIPTION
This does 2 things:
Exposes nginx and xdebug logs files to facilitate debugging.
Adds basic Xdebug configurations to work out of the box.

It is my current setup on Linux and has been tested lightly on Windows 10. It works as described, except on Windows the IP address is different for every setup - so I added a specific note for this on the readme. It should work out of the box for macs too but I don't have a way to test it.