### PR TITLE
Use official elasticsearch docker image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: memcached:latest
     restart: always
   elasticsearch:
-    image: elasticsearch:5
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.3
     restart: always
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"


### PR DESCRIPTION
Issue #59 
Add docker official image of elasticsearch with version 5.3.x to make compatible with elasticpress plugin.