### PR TITLE
Double quote positional paremeters to allow search asterisk

### DIFF
--- a/bin/wpsnapshots.sh
+++ b/bin/wpsnapshots.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec wpsnapshots /snapshots.sh $@
+docker-compose exec wpsnapshots /snapshots.sh "$@"


### PR DESCRIPTION
Fixes an issue where running the command `/bin/wpsnapshots.sh search "*"` was causing the bash interpreter to see a literal `*`, thus causing an issue with passing too many arguments to the search subcommand.