### PR TITLE
Remove strict subcommand switch cases in favor of direct proxy

### DIFF
--- a/images/wpsnapshots/snapshots.sh
+++ b/images/wpsnapshots/snapshots.sh
@@ -20,10 +20,7 @@ case "$1" in
         wpsnapshots "$@"
         mv /root/.wpsnapshots.json /wpsnapshots/.wpsnapshots.json
         ;;
-    push|pull|search|delete|create-repository)
-        maybe_run_wpsnapshots "$@"
-        ;;
     *)
-        exec "$@"
+        maybe_run_wpsnapshots "$@"
         ;;
 esac


### PR DESCRIPTION
Fixes an issue where running the `wpsnapshots.sh` command on the host with no arguments did not provide any output.