### PR TITLE
Add support for local phpMyAdmin for debugging

### DIFF
--- a/admin-compose.yml
+++ b/admin-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_HOST mysql
+    links:
+      - mysql:db
+    ports:
+      - 8092:80
+    depends_on:
+      - mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: password
+  phpmemcacheadmin:
+    image: hitwe/phpmemcachedadmin
+    ports:
+      - "8093:80"
+    depends_on:
+      - memcached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,18 +68,3 @@ services:
     volumes:
       - "./config/wpsnapshots:/wpsnapshots"
       - "./wordpress:/var/www/html"
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    environment:
-      - PMA_HOST mysql
-    links:
-      - mysql:db
-    ports:
-      - 8092:80
-    depends_on:
-      - mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-      MYSQL_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,3 +68,18 @@ services:
     volumes:
       - "./config/wpsnapshots:/wpsnapshots"
       - "./wordpress:/var/www/html"
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_HOST mysql
+    links:
+      - mysql:db
+    ports:
+      - 8092:80
+    depends_on:
+      - mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: password

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,25 @@ Host: mysql
 
 Default Elasticsearch connection information (from within PHP-FPM container):
 
-```Host: http://elasticsearch:9200```
+```
+Host: http://elasticsearch:9200
+```
 
 The Elasticsearch container is configured for a maximum heap size of 750MB to prevent out of memory crashes when using the default 2GB memory limit enforced by Docker for Mac and Docker for Windows installations or for Linux installations limited to less than 2GB. If you require additional memory for Elasticsearch override the value in a `docker-compose.override.yml` file as described below.
+
+## Administrative Tools
+
+We've bundled a simple administrative override file to aid in local development where appropriate. This file introduces both [phpMyAdmin](https://www.phpmyadmin.net/) and [phpMemcachedAdmin](https://github.com/elijaa/phpmemcachedadmin) to the Docker network for local administration of the database and object cache, respectively.
+
+You can run this atop a standard Docker installation by specifying _both_ the standard and the override configuration when initializing the service:
+
+```
+docker-compose -f docker-compose.yml -f admin-compose.yml up
+```
+
+The database tools can be accessed [on port 8092](http://localhost:8092).
+
+The cache tools can be accessed [on port 8093](http://localhost:8093).
 
 ## Docker Compose Overrides File
 


### PR DESCRIPTION
It's useful to have some tools locally for database debugging, specifically phpMyAdmin. This avoids needing other thick clients (like MySQL Workbench) alongside a development environment.