### PR TITLE
Fix xDebug extension path

### DIFF
--- a/config/php-fpm/docker-php-ext-xdebug.ini
+++ b/config/php-fpm/docker-php-ext-xdebug.ini
@@ -1,1 +1,1 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20160303/xdebug.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so


### PR DESCRIPTION
The xDebug paths were updated at some point. Without this, xDebug doesn't work for me, instead I get this:

[![Screenshot from Gyazo](https://gyazo.com/84b68c25bec34affb0afd463678dd998/raw)](https://gyazo.com/84b68c25bec34affb0afd463678dd998)