### PR TITLE
Feature / Prompt User for Admin Password on CLI Based Setup

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -31,7 +31,12 @@ REM Install WordPress
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec --user www-data phpfpm wp core config --force
 
-REM Set default password if none was provided
+REM Set default admin user if none was provided
+if "" == "%ADMIN_USER%" (
+	SET ADMIN_USER="admin"
+)
+
+REM Set default admin password if none was provided
 if "" == "%ADMIN_WP_PASSWORD%" (
 	SET ADMIN_PASSWORD="password"
 )

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -18,6 +18,9 @@ SET /P TITLE=[Site title: ]
 REM Ask for the user name
 SET /P ADMIN_USER=[Username: ]
 
+REM Ask for the user password
+SET /P ADMIN_WP_PASSWORD=[Password: ]
+
 REM Ask for the user email
 SET /P ADMIN_EMAIL=[Your Email: ]
 
@@ -28,10 +31,15 @@ REM Install WordPress
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec --user www-data phpfpm wp core config --force
 
+REM Set default password if none was provided
+if "" == "%ADMIN_WP_PASSWORD%" (
+	SET ADMIN_PASSWORD="password"
+)
+
 if "y" == "%MULTISITE%" (
-	SET ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%")
+	SET ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%" --admin_password="%ADMIN_WP_PASSWORD%")
 ) else (
-	SET ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%")
+	SET ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%" --admin_password="%ADMIN_WP_PASSWORD%")
 )
 
 REM Adjust settings

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -22,6 +22,10 @@ read TITLE
 echo -n "Username: "
 read ADMIN_USER
 
+# Ask for the user password
+echo -n "Password: "
+read ADMIN_WP_PASSWORD
+
 # Ask for the user email
 echo -n "Your Email: "
 read ADMIN_EMAIL
@@ -34,11 +38,17 @@ read MULTISITE
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec -T --user www-data phpfpm wp core config --force
 
+# Set default password if none was provided
+if [ "" = "$ADMIN_WP_PASSWORD" ]
+then
+    ADMIN_WP_PASSWORD="password"
+fi
+
 if [ "y" = "$MULTISITE" ]
 then
-	ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL")
+	ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL" --admin_password="$ADMIN_WP_PASSWORD")
 else
-	ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL")
+	ADMIN_PASSWORD=$(docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL" --admin_password="$ADMIN_WP_PASSWORD")
 fi
 
 # Adjust settings

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -38,7 +38,13 @@ read MULTISITE
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec -T --user www-data phpfpm wp core config --force
 
-# Set default password if none was provided
+# Set default admin user if none was provided
+if [ "" = "$ADMIN_USER" ]
+then
+    ADMIN_USER="admin"
+fi
+
+# Set default admin password if none was provided
 if [ "" = "$ADMIN_WP_PASSWORD" ]
 then
     ADMIN_WP_PASSWORD="password"

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,15 @@ Password: password
 Host: mysql
 ```
 
+Default WordPress admin credentials:
+
+```
+Username: admin
+Password: password
+```
+
+Note: if you provided details different to the above during setup, use those instead.
+
 Default Elasticsearch connection information (from within PHP-FPM container):
 
 ```


### PR DESCRIPTION
Upon using the script to set up a new site, I noticed that the setup.sh file (and upon investigation, the setup.bat file as well) had been updated to prompt the user for some info prior to site creation. However, there was a prompt for admin email and admin username, but not for admin password. 

Upon successful WordPress set up, I was unable to log in using the password "admin", "password" or "wordpress".

Upon further investigation, I noticed that the "admin_password" parameter was omitted from the WP-CLI based `wp core install` command, thus resulting in a randomly generated password being created.

In order to ease the on boarding of users who may be new to using WP Local Docker, I have updated both the setup.sh and setup.bash files to prompt the user for an admin password.

If no password is supplied, the password defaults to "password". This can be seen in action here:

https://cl.ly/3f2k122o3g0C

**UPDATE 01: 2018-04-16 22h35 SAST**

I updated the PR to include default fallback for admin usernames as well. The default admin user name is "admin" if none is provided. Thus, the default admin username and password if neither are provided is _admin:password_.

**UPDATE 02: 2018-04-16 22h39 SAST**

Updated the _readme.md_ file to provide a little context into the default admin and password values if none were provided during the setup.