### PR TITLE
Replacing Admin Password Output at End of CLI Setup Process With User Chosen Password

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -94,5 +94,5 @@ if "y" = "%INSTALL_DEVELOPER_PLUGIN%" (
 echo "Installation done."
 echo "------------------"
 echo "Admin Username: %ADMIN_USER%"
-echo "%ADMIN_PASSWORD%"
+echo "Admin Password: %ADMIN_WP_PASSWORD%"
 start "" http://localhost/wp-login.php

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -115,5 +115,5 @@ fi
 echo "Installation done."
 echo "------------------"
 echo "Admin username: $ADMIN_USER"
-echo "$ADMIN_PASSWORD"
+echo "Admin password: $ADMIN_WP_PASSWORD"
 open http://localhost/wp-login.php


### PR DESCRIPTION
This is related to issue #88 

I have added the user chosen (or default password) as part of the CLI based setup output upon completion.

I am wondering however, should we perhaps keep it to a randomly generated password if the user did not choose a password (i.e left it blank) or is it fine to default it to "password" (we do that for the DB anyway, so I don't foresee issues there).

Thanks!