### PR TITLE
Persist Elasticsearch index to disk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - "./config/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"
       - "./config/elasticsearch/plugins:/usr/share/elasticsearch/plugins"
+      - "./data/elasticsearch:/usr/share/elasticsearch/data"
   phpfpm:
     image: 10up/phpfpm
     depends_on:


### PR DESCRIPTION
Currently ES indexes are wiped if the container is removed - which happens every time you add/remove a config to it on `docker-compose.overrides.yml` and is also the only way to fix broken/corrupt containers - which sometimes happens if the host crashes while the container is in use. 

This can be a big issue on local setups, having to reindex frequently, but especially when dealing with large indexes (the one I'm working on right now takes over an hour to index). Persisting the indexes to disk the same way it is done for mysql mitigates this issue.