### PR TITLE
Simplify the install script to make use of native wp-cli prompts

### DIFF
--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -12,18 +12,6 @@ if exist "./wordpress/wp-config.php" (
 	)
 )
 
-REM Ask for the site title
-SET /P TITLE=[Site title: ]
-
-REM Ask for the user name
-SET /P ADMIN_USER=[Username: ]
-
-REM Ask for the user password
-SET /P ADMIN_PASSWORD=[Password: ]
-
-REM Ask for the user email
-SET /P ADMIN_EMAIL=[Your Email: ]
-
 REM Ask for the type of installation
 SET /P MULTISITE=[Do you want a multisite installation? [y/n] ]
 
@@ -31,20 +19,10 @@ REM Install WordPress
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec --user www-data phpfpm wp core config --force
 
-REM Set default admin user if none was provided
-if "" == "%ADMIN_USER%" (
-	SET ADMIN_USER="admin"
-)
-
-REM Set default admin password if none was provided
-if "" == "%ADMIN_PASSWORD%" (
-	SET ADMIN_PASSWORD="password"
-)
-
 if "y" == "%MULTISITE%" (
-	docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%" --admin_password="%ADMIN_PASSWORD%"
+	docker-compose exec --user www-data phpfpm wp core multisite-install --prompt
 ) else (
-	docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="%TITLE%" --admin_user="%ADMIN_USER%" --admin_email="%ADMIN_EMAIL%" --admin_password="%ADMIN_PASSWORD%"
+	docker-compose exec --user www-data phpfpm wp core install --prompt
 )
 
 REM Adjust settings
@@ -74,6 +52,3 @@ if "y" == "%EMPTY_CONTENT%" (
 
 echo "Installation done."
 echo "------------------"
-echo "Admin Username: %ADMIN_USER%"
-echo "Admin Password: %ADMIN_PASSWORD%"
-start "" http://localhost/wp-login.php

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -14,22 +14,6 @@ if [ -f "./wordpress/wp-config.php" ]; then
 	fi
 fi
 
-# Ask for the site title
-echo -n "Site title: "
-read TITLE
-
-# Ask for the user name
-echo -n "Username: "
-read ADMIN_USER
-
-# Ask for the user password
-echo -n "Password: "
-read ADMIN_PASSWORD
-
-# Ask for the user email
-echo -n "Your Email: "
-read ADMIN_EMAIL
-
 # Ask for the type of installation
 echo -n "Do you want a multisite installation? [y/n] "
 read MULTISITE
@@ -38,23 +22,11 @@ read MULTISITE
 docker-compose exec --user www-data phpfpm wp core download --force
 docker-compose exec -T --user www-data phpfpm wp core config --force
 
-# Set default admin user if none was provided
-if [ "" = "$ADMIN_USER" ]
-then
-	ADMIN_USER="admin"
-fi
-
-# Set default admin password if none was provided
-if [ "" = "$ADMIN_PASSWORD" ]
-then
-	ADMIN_PASSWORD="password"
-fi
-
 if [ "y" = "$MULTISITE" ]
 then
-	docker-compose exec --user www-data phpfpm wp core multisite-install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL" --admin_password="$ADMIN_PASSWORD"
+	docker-compose exec --user www-data phpfpm wp core multisite-install --prompt
 else
-	docker-compose exec --user www-data phpfpm wp core install --url=localhost --title="$TITLE" --admin_user="$ADMIN_USER" --admin_email="$ADMIN_EMAIL" --admin_password="$ADMIN_PASSWORD"
+	docker-compose exec --user www-data phpfpm wp core install --prompt
 fi
 
 # Adjust settings
@@ -86,6 +58,3 @@ fi
 
 echo "Installation done."
 echo "------------------"
-echo "Admin username: $ADMIN_USER"
-echo "Admin password: $ADMIN_PASSWORD"
-open http://localhost/wp-login.php


### PR DESCRIPTION
WP-CLI provides a handy `--prompt` flag that can be used with any command that takes arguments. We can leverage this to make the setup script less opinionated and easier to maintain, at the same time presenting more options to the user.

The current setup forces the installation on localhost which makes subdomain-based networks impossible out of the box. This is a more flexible approach.

