### PR TITLE
update xdebug path to match the new images

### DIFF
--- a/config/php-fpm/docker-php-ext-xdebug.ini
+++ b/config/php-fpm/docker-php-ext-xdebug.ini
@@ -1,1 +1,1 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
+zend_extension=/usr/local/lib/php/extensions/xdebug.so


### PR DESCRIPTION
this adds a permanent fix to #86 and solves #110. To be used in conjunction with https://github.com/10up/wp-local-docker-images/pull/9