### PR TITLE
remove the always-restart policy 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: mysql:5
     volumes:
       - "./data/db:/var/lib/mysql"
-    restart: always
     ports:
       - "3306:3306"
     environment:
@@ -14,7 +13,6 @@ services:
       MYSQL_PASSWORD: password
   mailcatcher:
      image: schickling/mailcatcher
-     restart: always
      ports:
        - "1025:1025"
        - "1080:1080"
@@ -22,10 +20,8 @@ services:
        MAILCATCHER_PORT: 1025
   memcached:
     image: memcached:latest
-    restart: always
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.5
-    restart: always
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"
     ports:
@@ -45,7 +41,6 @@ services:
       - "./config/php-fpm/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
       - "./config/php-fpm/wp-cli.local.yml:/var/www/html/wp-cli.local.yml"
       - ~/.ssh:/root/.ssh
-    restart: always
     extra_hosts:
       - "docker-local.localhost:172.18.0.1"
   nginx:
@@ -60,7 +55,6 @@ services:
       - "./config/nginx/default.conf:/etc/nginx/conf.d/default.conf"
       - "./config/certs:/etc/nginx/certs"
       - "./logs/nginx:/var/log/nginx"
-    restart: always
   wpsnapshots:
     image: 10up/wpsnapshots
     depends_on:


### PR DESCRIPTION
to avoid containers racing to restart after a system crash or reboot - doesn't look like a very useful feature for a development environment where multiple containers exist with the same name but on different projects.

~~fixes #116~~ (unrelated)