### PR TITLE
Update docker-stop() helper definition remove stopped containers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ To increase efficiency with WP Local Docker, the following bash aliases can be a
     ```
 3. Multiple instances cannot be run simultaneously. In order to switch projects, you'll need to kill all Docker containers first: 
     ```bash
-    docker-stop() { docker stop $(docker ps -a -q); }
+    docker-stop() { docker stop $(docker ps -aq) && docker rm $(docker ps -aq) }
     ```
 4. Combine the stop-all command with `docker-compose up` to easily start up an instance with one command: 
     ```bash


### PR DESCRIPTION
@tlovett1 I think we should update this recommended function to remove the containers after stopping them, otherwise the references will remain in the output of `docker ps -a`.