### PR TITLE
update docker-compose mysql service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   mysql:
     image: mysql:5
     volumes:
-      - "./data/db:/var/lib/mysql:delegated"
+      - db-volume:/var/lib/mysql
+      - "./data/db:/docker-entrypoint-initdb.d"
     ports:
       - "3306:3306"
     environment:
@@ -64,3 +65,6 @@ services:
     volumes:
       - "./config/wpsnapshots:/home/wpsnapshots/.wpsnapshots"
       - "./wordpress:/var/www/html"
+
+volumes:
+  db-volume:


### PR DESCRIPTION
I found problems with Docker Machine users on Windows 10 to have the following error at container creation time
```
[ERROR] InnoDB: Operating system error number 22 in a file operation.
[ERROR] InnoDB: Error number 22 means 'Invalid argument'
[ERROR] InnoDB: File ./ib_logfile101: 'aio write' returned OS error 122. Cannot continue operation
```

To solve that, I mount the db data to a named volume, in this way a `docker-compose down` won't destroy data, unless you use the `-v` option
https://docs.docker.com/compose/reference/down/

I even mount the "data/db" folder to the internal mysql docker container folder "/docker-entrypoint-initdb.d" to enable auto import if there is any SQL file (like a backup).
read more at https://hub.docker.com/_/mysql/ at "Initializing a fresh instance" paragraph

The database files are not anymore visible under "data/db" because the named volume is only internally monuted inside the mysql container.
Obviously the database can still be access via WP CLI or PhpMyAdmin.